### PR TITLE
AZD bicep fix for DB container

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -137,7 +137,7 @@ resource sqlContainerPurchaseHistory 'Microsoft.DocumentDB/databaseAccounts/sqlD
   }
 }
 
-resource sqlContainerChat 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-11-15' = {
+resource sqlContainerChat 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2025-05-01-preview' = {
   parent: sqlDatabase
   name: 'Chat'
   properties: {
@@ -146,6 +146,7 @@ resource sqlContainerChat 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/co
       partitionKey: {
         paths: ['/user_id', '/session_id']
         kind: 'MultiHash'
+        version: 2
       }
     }
   }


### PR DESCRIPTION
Fix: version `2025-05-01-preview` change required for db container configuration

```
resource sqlContainerChat 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2025-05-01-preview' = {
  parent: sqlDatabase
  name: 'Chat'
  properties: {
    resource: {
      id: 'Chat'
      partitionKey: {
        paths: ['/user_id', '/session_id']
        kind: 'MultiHash'
        version: 2
      }
    }
  }
}
```

Error without fix: 

```
ERROR: error executing step command 'provision': deployment failed: error deploying infrastructure: deploying to resource group:

Deployment Error Details:
BadRequest: Message: {"code":"BadRequest","message":"Message: {\"Errors\":[\"Invalid version for Hash kind MultiHash.\"]}\r\nActivityId: 65e809f6-a5bf-4dd0-895f-961c6ef1942e, Request URI: /apps/4c1e0239-1a40-45b4-963e-0acde0edb01a/services/12a52576-5010-4f1c-8404-39e6f89901f4/partitions/c1ce09c9-a489-46fc-9a0f-3c8e126bda14/replicas/133990116024600528p, RequestStats: , SDK: Microsoft.Azure.Documents.Common/2.14.0"}, Request URI: /dbs/MultiAgentDemoDB/colls, RequestStats: , SDK: Microsoft.Azure.Documents.Common/2.14.0, Microsoft.Azure.Documents.Common/2.14.0, Microsoft.Azure.Documents.Common/2.14.0, Microsoft.Azure.Documents.Common/2.14.0, Microsoft.Azure.Documents.Common/2.14.0
```